### PR TITLE
Guard role grant emission behind WillSyncResourceType

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -12,12 +12,13 @@ import (
 )
 
 type Connector struct {
-	client *client.NotionClient
+	client        *client.NotionClient
+	connectorOpts *cli.ConnectorOpts
 }
 
 func (d *Connector) ResourceSyncers(_ context.Context) []connectorbuilder.ResourceSyncerV2 {
 	return []connectorbuilder.ResourceSyncerV2{
-		newUserBuilder(d.client),
+		newUserBuilder(d.client, d.connectorOpts),
 		newGroupBuilder(d.client),
 		newRoleBuilder(d.client),
 	}
@@ -78,6 +79,7 @@ func New(ctx context.Context, cfg *config.Notion, opts *cli.ConnectorOpts) (conn
 	}
 
 	return &Connector{
-		client: scimClient,
+		client:        scimClient,
+		connectorOpts: opts,
 	}, nil, nil
 }

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -6,11 +6,13 @@ import (
 )
 
 var (
+	// userResourceType carries no static annotations: userBuilder.ResourceType
+	// computes SkipEntitlements or SkipEntitlementsAndGrants dynamically based
+	// on whether "role" is included in the sync (see user.go).
 	userResourceType = &v2.ResourceType{
 		Id:          "user",
 		DisplayName: "User",
 		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER},
-		Annotations: annotations.New(&v2.SkipEntitlements{}),
 	}
 
 	groupResourceType = &v2.ResourceType{

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -60,12 +60,7 @@ var _ connectorbuilder.AccountManagerV2 = &userBuilder{}
 // so concurrent/repeated calls with different syncRoles values can't leak
 // annotations onto each other via a shared pointer.
 func (b *userBuilder) ResourceType(_ context.Context) *v2.ResourceType {
-	rt, ok := proto.Clone(userResourceType).(*v2.ResourceType)
-	if !ok {
-		// proto.Clone on a *v2.ResourceType always yields a *v2.ResourceType;
-		// this branch is unreachable in practice.
-		return userResourceType
-	}
+	rt := proto.Clone(userResourceType).(*v2.ResourceType)
 
 	annos := annotations.Annotations(rt.Annotations)
 	if b.syncRoles {

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -7,6 +7,7 @@ import (
 	"github.com/conductorone/baton-notion/pkg/client"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/cli"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	sdkGrant "github.com/conductorone/baton-sdk/pkg/types/grant"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
@@ -24,6 +25,17 @@ const profileKeyWorkspaceRole = "workspace_role"
 
 type userBuilder struct {
 	client *client.NotionClient
+
+	// syncRoles gates the role-grant emission in Grants below. userBuilder
+	// emits role grants on roleBuilder's behalf (see role.go) as a sync
+	// optimization -- the user API response already includes the workspace
+	// role, so roleBuilder.Grants is a no-op delegate. If a customer's sync
+	// filter excludes the "role" resource type (SyncResourceTypeIDs), the SDK
+	// never syncs role resources at all, so emitting a grant that references
+	// roleResourceType would be wasted work referencing a type that was never
+	// synced. syncRoles defaults to true (sync everything) when no filter is
+	// configured, matching cli.ConnectorOpts.WillSyncResourceType semantics.
+	syncRoles bool
 }
 
 var _ connectorbuilder.AccountManagerV2 = &userBuilder{}
@@ -80,7 +92,16 @@ func (b *userBuilder) Entitlements(_ context.Context, _ *v2.Resource, _ rs.SyncO
 // A role value that is not one of the four documented Notion roles is logged
 // at Warn and the grant is skipped — this surfaces silent drift (e.g. Notion
 // introducing a new tier) instead of dropping users invisibly.
+//
+// The role-grant emission is gated on syncRoles: if the sync filter excludes
+// the "role" resource type, roleBuilder never syncs role resources, so
+// emitting a grant against roleResourceType here would reference a type the
+// SDK never listed -- wasted work and a dangling reference.
 func (b *userBuilder) Grants(ctx context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
+	if !b.syncRoles {
+		return nil, nil, nil
+	}
+
 	role := workspaceRoleFromResource(resource)
 	if role == "" {
 		return nil, nil, nil
@@ -253,8 +274,20 @@ func parseIntoUserResource(user client.User) (*v2.Resource, error) {
 	return ret, nil
 }
 
-func newUserBuilder(scimClient *client.NotionClient) *userBuilder {
+// newUserBuilder wires connectorOpts' sync filter into userBuilder so
+// Grants can skip emitting role grants when "role" is excluded from the
+// sync (see the syncRoles field doc on userBuilder). connectorOpts may be
+// nil (e.g. constructed directly in tests); a nil filter means "sync
+// everything", matching cli.ConnectorOpts.WillSyncResourceType's own
+// no-filter-set behavior.
+func newUserBuilder(scimClient *client.NotionClient, connectorOpts *cli.ConnectorOpts) *userBuilder {
+	syncRoles := true
+	if connectorOpts != nil {
+		syncRoles = connectorOpts.WillSyncResourceType(roleResourceType.Id)
+	}
+
 	return &userBuilder{
-		client: scimClient,
+		client:    scimClient,
+		syncRoles: syncRoles,
 	}
 }

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -13,6 +13,7 @@ import (
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -26,22 +27,55 @@ const profileKeyWorkspaceRole = "workspace_role"
 type userBuilder struct {
 	client *client.NotionClient
 
-	// syncRoles gates the role-grant emission in Grants below. userBuilder
-	// emits role grants on roleBuilder's behalf (see role.go) as a sync
-	// optimization -- the user API response already includes the workspace
-	// role, so roleBuilder.Grants is a no-op delegate. If a customer's sync
-	// filter excludes the "role" resource type (SyncResourceTypeIDs), the SDK
-	// never syncs role resources at all, so emitting a grant that references
-	// roleResourceType would be wasted work referencing a type that was never
-	// synced. syncRoles defaults to true (sync everything) when no filter is
-	// configured, matching cli.ConnectorOpts.WillSyncResourceType semantics.
+	// syncRoles gates whether "role" is included in this sync (see
+	// ResourceType below). userBuilder emits role grants on roleBuilder's
+	// behalf (see role.go) as a sync optimization -- the user API response
+	// already includes the workspace role, so roleBuilder.Grants is a no-op
+	// delegate. If a customer's sync filter excludes the "role" resource type
+	// (SyncResourceTypeIDs), role resources are never synced at all, so a
+	// grant that references roleResourceType would be a dangling reference to
+	// a type the SDK never listed. syncRoles defaults to true (sync
+	// everything) when no filter is configured, matching
+	// cli.ConnectorOpts.WillSyncResourceType semantics.
 	syncRoles bool
 }
 
 var _ connectorbuilder.AccountManagerV2 = &userBuilder{}
 
+// ResourceType returns userResourceType with annotations computed from
+// syncRoles, rather than the package var's own (nil) annotations. The SDK
+// decides whether to call Entitlements/Grants for a resource type based on
+// the annotations returned here -- not by any runtime check inside those
+// methods -- so gating happens at this layer instead of inside Grants.
+//
+// user has no entitlements of its own, ever, so when "role" IS being synced
+// we set SkipEntitlements (matching the connector's long-standing static
+// behavior). When "role" is NOT being synced, we set
+// SkipEntitlementsAndGrants instead: this tells the SDK to skip calling both
+// Entitlements and Grants for user resources entirely, which is what
+// prevents Grants from emitting a role grant that references a resource
+// type the SDK never listed.
+//
+// A clone of userResourceType is returned -- never the package var itself --
+// so concurrent/repeated calls with different syncRoles values can't leak
+// annotations onto each other via a shared pointer.
 func (b *userBuilder) ResourceType(_ context.Context) *v2.ResourceType {
-	return userResourceType
+	rt, ok := proto.Clone(userResourceType).(*v2.ResourceType)
+	if !ok {
+		// proto.Clone on a *v2.ResourceType always yields a *v2.ResourceType;
+		// this branch is unreachable in practice.
+		return userResourceType
+	}
+
+	annos := annotations.Annotations(rt.Annotations)
+	if b.syncRoles {
+		annos.Append(&v2.SkipEntitlements{})
+	} else {
+		annos.Append(&v2.SkipEntitlementsAndGrants{})
+	}
+	rt.Annotations = annos
+
+	return rt
 }
 
 func (b *userBuilder) List(ctx context.Context, _ *v2.ResourceId, attrs rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
@@ -93,15 +127,13 @@ func (b *userBuilder) Entitlements(_ context.Context, _ *v2.Resource, _ rs.SyncO
 // at Warn and the grant is skipped — this surfaces silent drift (e.g. Notion
 // introducing a new tier) instead of dropping users invisibly.
 //
-// The role-grant emission is gated on syncRoles: if the sync filter excludes
-// the "role" resource type, roleBuilder never syncs role resources, so
-// emitting a grant against roleResourceType here would reference a type the
-// SDK never listed -- wasted work and a dangling reference.
+// Grants is unconditional: it always emits the role grant when the user has
+// one, regardless of syncRoles. Gating on whether "role" is included in the
+// sync happens in ResourceType instead, via the SkipEntitlementsAndGrants
+// annotation -- the SDK decides whether to call Grants for user resources at
+// all based on that, so by the time Grants runs here, the SDK has already
+// decided the grant is wanted.
 func (b *userBuilder) Grants(ctx context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
-	if !b.syncRoles {
-		return nil, nil, nil
-	}
-
 	role := workspaceRoleFromResource(resource)
 	if role == "" {
 		return nil, nil, nil

--- a/pkg/connector/user_test.go
+++ b/pkg/connector/user_test.go
@@ -1,0 +1,128 @@
+package connector
+
+import (
+	"context"
+	"testing"
+
+	"github.com/conductorone/baton-notion/pkg/client"
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/cli"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+)
+
+// newTestUserResourceWithRole builds a *v2.Resource the same way List() does,
+// so Grants() sees a resource shaped exactly like the real sync path.
+func newTestUserResourceWithRole(t *testing.T, role string) *v2.Resource {
+	t.Helper()
+
+	u := client.User{
+		ID:       "user-1",
+		UserName: "person@example.com",
+		Active:   true,
+	}
+	u.Name.GivenName = "Person"
+	u.Name.FamilyName = "One"
+	u.Name.Formatted = "Person One"
+	if role != "" {
+		u.NotionExtension = &client.NotionUserExtension{Role: role}
+	}
+
+	res, err := parseIntoUserResource(u)
+	if err != nil {
+		t.Fatalf("parseIntoUserResource: %v", err)
+	}
+	return res
+}
+
+// TestUserBuilder_Grants_RoleGating asserts that userBuilder.Grants only
+// emits the cross-type role grant (see role.go: roleBuilder.Grants is a
+// no-op delegate to this method) when the "role" resource type is included
+// in the sync -- either because no explicit filter was configured, or
+// because "role" was explicitly selected. When a customer's sync filter
+// excludes "role", no role grant should be emitted, since roleBuilder never
+// lists role resources for that grant to reference.
+func TestUserBuilder_Grants_RoleGating(t *testing.T) {
+	tests := []struct {
+		name         string
+		syncRoles    bool
+		wantGrantLen int
+	}{
+		{
+			name:         "role type synced (default/no filter or explicit) -> role grant emitted",
+			syncRoles:    true,
+			wantGrantLen: 1,
+		},
+		{
+			name:         "role type excluded from sync filter -> no role grant emitted",
+			syncRoles:    false,
+			wantGrantLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &userBuilder{syncRoles: tt.syncRoles}
+
+			userResource := newTestUserResourceWithRole(t, client.RoleMember)
+
+			grants, _, err := b.Grants(context.Background(), userResource, rs.SyncOpAttrs{})
+			if err != nil {
+				t.Fatalf("Grants returned error: %v", err)
+			}
+
+			if len(grants) != tt.wantGrantLen {
+				t.Fatalf("expected %d grants, got %d: %+v", tt.wantGrantLen, len(grants), grants)
+			}
+
+			if tt.wantGrantLen > 0 {
+				got := grants[0].Entitlement.Resource.Id.ResourceType
+				if got != roleResourceType.Id {
+					t.Fatalf("expected grant to reference resource type %q, got %q", roleResourceType.Id, got)
+				}
+			}
+		})
+	}
+}
+
+// TestNewUserBuilder_SyncRolesWiring covers the constructor wiring: nil
+// connectorOpts and an opts value with no explicit filter both mean "sync
+// everything", matching cli.ConnectorOpts.WillSyncResourceType's own
+// no-filter semantics. An explicit filter that excludes "role" should
+// compute syncRoles=false; one that includes it should compute true.
+func TestNewUserBuilder_SyncRolesWiring(t *testing.T) {
+	tests := []struct {
+		name          string
+		connectorOpts *cli.ConnectorOpts
+		wantSyncRoles bool
+	}{
+		{
+			name:          "nil opts -> sync everything",
+			connectorOpts: nil,
+			wantSyncRoles: true,
+		},
+		{
+			name:          "opts with no filter set -> sync everything",
+			connectorOpts: &cli.ConnectorOpts{},
+			wantSyncRoles: true,
+		},
+		{
+			name:          "opts with role explicitly included",
+			connectorOpts: &cli.ConnectorOpts{SyncResourceTypeIDs: []string{"user", "role"}},
+			wantSyncRoles: true,
+		},
+		{
+			name:          "opts with role explicitly excluded",
+			connectorOpts: &cli.ConnectorOpts{SyncResourceTypeIDs: []string{"user", "group"}},
+			wantSyncRoles: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := newUserBuilder(nil, tt.connectorOpts)
+			if b.syncRoles != tt.wantSyncRoles {
+				t.Fatalf("expected syncRoles=%v, got %v", tt.wantSyncRoles, b.syncRoles)
+			}
+		})
+	}
+}

--- a/pkg/connector/user_test.go
+++ b/pkg/connector/user_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/conductorone/baton-notion/pkg/client"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/cli"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 )
@@ -34,29 +35,22 @@ func newTestUserResourceWithRole(t *testing.T, role string) *v2.Resource {
 	return res
 }
 
-// TestUserBuilder_Grants_RoleGating asserts that userBuilder.Grants only
-// emits the cross-type role grant (see role.go: roleBuilder.Grants is a
-// no-op delegate to this method) when the "role" resource type is included
-// in the sync -- either because no explicit filter was configured, or
-// because "role" was explicitly selected. When a customer's sync filter
-// excludes "role", no role grant should be emitted, since roleBuilder never
-// lists role resources for that grant to reference.
-func TestUserBuilder_Grants_RoleGating(t *testing.T) {
+// TestUserBuilder_Grants_AlwaysEmitsRoleGrant asserts that userBuilder.Grants
+// unconditionally emits the cross-type role grant (see role.go:
+// roleBuilder.Grants is a no-op delegate to this method) whenever the user
+// has a supported role, regardless of syncRoles. Gating on whether "role" is
+// included in the sync now happens in ResourceType via annotations (see
+// TestUserBuilder_ResourceType_Annotations below), not inside Grants itself
+// -- when "role" is excluded from the sync, the SDK simply never calls
+// Grants for user resources at all, so Grants has no need to check syncRoles
+// on its own.
+func TestUserBuilder_Grants_AlwaysEmitsRoleGrant(t *testing.T) {
 	tests := []struct {
-		name         string
-		syncRoles    bool
-		wantGrantLen int
+		name      string
+		syncRoles bool
 	}{
-		{
-			name:         "role type synced (default/no filter or explicit) -> role grant emitted",
-			syncRoles:    true,
-			wantGrantLen: 1,
-		},
-		{
-			name:         "role type excluded from sync filter -> no role grant emitted",
-			syncRoles:    false,
-			wantGrantLen: 0,
-		},
+		{name: "syncRoles=true -> role grant emitted", syncRoles: true},
+		{name: "syncRoles=false -> role grant still emitted", syncRoles: false},
 	}
 
 	for _, tt := range tests {
@@ -70,17 +64,93 @@ func TestUserBuilder_Grants_RoleGating(t *testing.T) {
 				t.Fatalf("Grants returned error: %v", err)
 			}
 
-			if len(grants) != tt.wantGrantLen {
-				t.Fatalf("expected %d grants, got %d: %+v", tt.wantGrantLen, len(grants), grants)
+			if len(grants) != 1 {
+				t.Fatalf("expected 1 grant, got %d: %+v", len(grants), grants)
 			}
 
-			if tt.wantGrantLen > 0 {
-				got := grants[0].Entitlement.Resource.Id.ResourceType
-				if got != roleResourceType.Id {
-					t.Fatalf("expected grant to reference resource type %q, got %q", roleResourceType.Id, got)
-				}
+			got := grants[0].Entitlement.Resource.Id.ResourceType
+			if got != roleResourceType.Id {
+				t.Fatalf("expected grant to reference resource type %q, got %q", roleResourceType.Id, got)
 			}
 		})
+	}
+}
+
+// TestUserBuilder_ResourceType_Annotations asserts that ResourceType sets the
+// annotation the SDK uses to decide whether to call Entitlements/Grants for
+// user resources: SkipEntitlements when "role" is being synced (user still
+// has no entitlements of its own), or SkipEntitlementsAndGrants when it is
+// not (so the SDK skips calling Grants entirely, since userBuilder.Grants
+// would otherwise emit a dangling role grant). The two annotations are
+// mutually exclusive -- SkipEntitlementsAndGrants supersedes
+// SkipEntitlements, so both should never be set at once.
+func TestUserBuilder_ResourceType_Annotations(t *testing.T) {
+	tests := []struct {
+		name                          string
+		syncRoles                     bool
+		wantSkipEntitlements          bool
+		wantSkipEntitlementsAndGrants bool
+	}{
+		{
+			name:                          "syncRoles=true -> SkipEntitlements only",
+			syncRoles:                     true,
+			wantSkipEntitlements:          true,
+			wantSkipEntitlementsAndGrants: false,
+		},
+		{
+			name:                          "syncRoles=false -> SkipEntitlementsAndGrants only",
+			syncRoles:                     false,
+			wantSkipEntitlements:          false,
+			wantSkipEntitlementsAndGrants: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &userBuilder{syncRoles: tt.syncRoles}
+
+			rt := b.ResourceType(context.Background())
+
+			annos := annotations.Annotations(rt.Annotations)
+			gotSkipEnts := annos.Contains(&v2.SkipEntitlements{})
+			gotSkipEntsAndGrants := annos.Contains(&v2.SkipEntitlementsAndGrants{})
+
+			if gotSkipEnts != tt.wantSkipEntitlements {
+				t.Fatalf("SkipEntitlements: expected %v, got %v", tt.wantSkipEntitlements, gotSkipEnts)
+			}
+			if gotSkipEntsAndGrants != tt.wantSkipEntitlementsAndGrants {
+				t.Fatalf("SkipEntitlementsAndGrants: expected %v, got %v", tt.wantSkipEntitlementsAndGrants, gotSkipEntsAndGrants)
+			}
+		})
+	}
+}
+
+// TestUserBuilder_ResourceType_DoesNotMutatePackageVar guards against a
+// regression where ResourceType mutates the package-level userResourceType
+// var in place (e.g. by appending annotations directly to it) instead of
+// operating on a clone. If that happened, repeated calls with different
+// syncRoles values would leak annotations onto each other through the shared
+// pointer, and worse, the package var itself would accumulate skip
+// annotations as a side effect of unrelated calls.
+func TestUserBuilder_ResourceType_DoesNotMutatePackageVar(t *testing.T) {
+	if len(userResourceType.Annotations) != 0 {
+		t.Fatalf("precondition failed: userResourceType already has annotations: %+v", userResourceType.Annotations)
+	}
+
+	trueBuilder := &userBuilder{syncRoles: true}
+	falseBuilder := &userBuilder{syncRoles: false}
+
+	for i := 0; i < 3; i++ {
+		_ = trueBuilder.ResourceType(context.Background())
+		_ = falseBuilder.ResourceType(context.Background())
+
+		annos := annotations.Annotations(userResourceType.Annotations)
+		if annos.Contains(&v2.SkipEntitlements{}) {
+			t.Fatalf("iteration %d: package var userResourceType picked up SkipEntitlements as a side effect", i)
+		}
+		if annos.Contains(&v2.SkipEntitlementsAndGrants{}) {
+			t.Fatalf("iteration %d: package var userResourceType picked up SkipEntitlementsAndGrants as a side effect", i)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- `userBuilder.Grants` emits a role grant on `roleBuilder`'s behalf (a permanent no-op delegate, see `role.go`) as a sync optimization — the Notion user API response already includes the workspace role.
- That emission was unconditional: if a customer's sync filter excluded the `role` resource type, `roleBuilder` never lists role resources, but `userBuilder` still emitted a grant referencing `roleResourceType` — a dangling reference to a type that was never synced.
- Gates this behind `cli.ConnectorOpts.WillSyncResourceType("role")`, following [ConductorOne/baton-linear#55](https://github.com/ConductorOne/baton-linear/pull/55). `WillSyncResourceType` returns `true` when the type is explicitly selected or when no filter is configured at all, so default/local runs are unaffected.
- **Approach**: gating lives at the `ResourceType()` annotation level, not as a runtime check inside `Grants()`. `userBuilder.ResourceType()` now returns a clone of `userResourceType` carrying `SkipEntitlements` when `role` is being synced (user has no entitlements of its own, unchanged from before), or `SkipEntitlementsAndGrants` when it isn't — which tells the SDK to skip calling `Entitlements`/`Grants` for `user` resources entirely, so `Grants()` itself stays unconditional and simple.
- **Scope note**: `group` was also named as a target to gate, but it doesn't apply here — `groupBuilder.Grants` computes its own membership grants independently via `GetGroup`, it's not a delegate of `userBuilder`. Only `role` has a cross-type emission in this connector.
- `baton_capabilities.json` / `config_schema.json` / `docs/connector.mdx` are unchanged — verified by rebuilding the binary and diffing: with no sync filter (the case `capabilities`/`config` run under), `WillSyncResourceType` returns `true` for everything, so the annotation computes to the same `SkipEntitlements` that was already statically present.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `pkg/connector/user_test.go`:
  - `TestUserBuilder_Grants_AlwaysEmitsRoleGrant` — `Grants()` emits the role grant unconditionally regardless of `syncRoles` (gating moved out of `Grants`).
  - `TestUserBuilder_ResourceType_Annotations` — `syncRoles=true` → `SkipEntitlements` only; `syncRoles=false` → `SkipEntitlementsAndGrants` only.
  - `TestUserBuilder_ResourceType_DoesNotMutatePackageVar` — repeated calls with different `syncRoles` never leak annotations onto the shared package-level `userResourceType` var.
  - `TestNewUserBuilder_SyncRolesWiring` — constructor wiring (nil opts, empty filter, filter including/excluding "role") unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
