### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -28,13 +28,14 @@ func groupResource(group *client.Group) (*v2.Resource, error) {
 		"group_name": group.DisplayName,
 	}
 
-	groupTraitOptions := []rs.GroupTraitOption{rs.WithGroupProfile(profile)}
+	groupTraitOptions := []rs.GroupTraitOption{}
 
 	ret, err := rs.NewGroupResource(
 		group.DisplayName,
 		groupResourceType,
 		group.ID,
 		groupTraitOptions,
+		rs.WithResourceProfile(profile),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -101,13 +101,12 @@ func (b *roleBuilder) ResourceType(_ context.Context) *v2.ResourceType {
 }
 
 func roleResource(role notionRole) (*v2.Resource, error) {
-	roleTraitOpts := []rs.RoleTraitOption{
-		rs.WithRoleProfile(map[string]any{
-			"role_id":           role.id,
-			"description":       role.description,
-			"is_administrative": role.id == client.RoleOwner || role.id == client.RoleMembershipAdmin,
-		}),
-	}
+	roleTraitOpts := []rs.RoleTraitOption{}
+	roleProfile := rs.WithResourceProfile(map[string]any{
+		"role_id":           role.id,
+		"description":       role.description,
+		"is_administrative": role.id == client.RoleOwner || role.id == client.RoleMembershipAdmin,
+	})
 
 	// EntitlementIDs links the seat counts back to the grants that consume
 	// them so the C1 App Utilization feature (CE-720) can map seat-holders to
@@ -128,6 +127,7 @@ func roleResource(role notionRole) (*v2.Resource, error) {
 		roleResourceType,
 		role.id,
 		roleTraitOpts,
+		roleProfile,
 		rs.WithLicenseProfileTrait(licenseOpts...),
 	)
 }

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -102,11 +102,7 @@ func (b *userBuilder) Grants(ctx context.Context, resource *v2.Resource, _ rs.Sy
 }
 
 func workspaceRoleFromResource(resource *v2.Resource) string {
-	ut, err := rs.GetUserTrait(resource)
-	if err != nil || ut == nil {
-		return ""
-	}
-	profile := ut.GetProfile()
+	profile := resource.GetProfile()
 	if profile == nil {
 		return ""
 	}
@@ -237,8 +233,6 @@ func parseIntoUserResource(user client.User) (*v2.Resource, error) {
 	}
 
 	userTraitOptions := []rs.UserTraitOption{
-		rs.WithStatus(userStatus),
-		rs.WithUserProfile(profile),
 		rs.WithUserLogin(user.UserName),
 		rs.WithEmail(user.UserName, true),
 	}
@@ -249,6 +243,8 @@ func parseIntoUserResource(user client.User) (*v2.Resource, error) {
 		userResourceType,
 		user.ID,
 		userTraitOptions,
+		rs.WithResourceProfile(profile),
+		rs.WithResourceStatus(v2.Status_ResourceStatus(userStatus), ""),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -102,7 +102,7 @@ func (b *userBuilder) Grants(ctx context.Context, resource *v2.Resource, _ rs.Sy
 }
 
 func workspaceRoleFromResource(resource *v2.Resource) string {
-	profile := resource.GetProfile()
+	profile := rs.GetProfile(resource)
 	if profile == nil {
 		return ""
 	}


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is currently red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.